### PR TITLE
Prevent assigning IP address from vm_network pool to mgmt interface.

### DIFF
--- a/puppet/occam/profile/files/occamengine/occamengine
+++ b/puppet/occam/profile/files/occamengine/occamengine
@@ -395,7 +395,7 @@ class Node < Sequel::Model
     if ! role.nil?
       self.role_id = role.id
       self.hostname = "#{role.role}#{role.suffix}"
-      i = DB[:nodes].select(:ip).order_by(:ip).last[:ip]
+      i = DB[:nodes].select(:ip).filter(:parent_id => nil).order_by(:ip).last[:ip]
       self.ip = $1 + ($2.to_i+1).to_s if i =~ /(\d+\.\d+\.\d+\.)(\d+)/
     end
   end


### PR DESCRIPTION
In provisioning process new node get IP address equal to last assigned
address + 1. Before get last assigned IP we must filter out addresses
from vm_network pool to not choose one of it as a base for
calculation of IP address reservation for mgmt interface of new node.
